### PR TITLE
Use S3-direct URLs for image resources.

### DIFF
--- a/403.html
+++ b/403.html
@@ -6,6 +6,6 @@ body{text-align:center;position:absolute;top:50%;margin:0;margin-top:-335px;widt
 h2,h3{color:#222;font:bold 200%/100px sans-serif;margin:0}
 h3{color:#777;font:normal 150% sans-serif}
 </style>
-<img src=//www.redditstatic.com/youbrokeit3.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/youbrokeit3.png alt="">
 <h2>you appear to be a bad robot</h2>
 <h3>check out <a href="http://github.com/reddit/reddit/wiki/API"> the rules for robots</a>. thanks.

--- a/403.nossl.html
+++ b/403.nossl.html
@@ -6,7 +6,7 @@ body{text-align:center;position:absolute;top:50%;margin:0;margin-top:-335px;widt
 h2,h3{color:#222;font:bold 200%/100px sans-serif;margin:0}
 h3{color:#777;font:normal 150% sans-serif}
 </style>
-<img src=//www.redditstatic.com/reddit404c.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/reddit404c.png alt="">
 <h2>you're trying to access a secure page without using SSL.</h2>
 <h3>If you're suddenly getting this and you don't know why, contact us at <a
  href="mailto:broken [at] reddit (dot) com">broken [at] reddit (dot) com</a>.

--- a/502.html
+++ b/502.html
@@ -6,6 +6,6 @@ body{text-align:center;position:absolute;top:50%;margin:0;margin-top:-340px;widt
 h2,h3{color:#222;font:bold 200%/100px sans-serif;margin:0}
 h3{color:#777;font:normal 150% sans-serif}
 </style>
-<img src=//www.redditstatic.com/youbrokeit1.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/youbrokeit1.png alt="">
 <h2>we took too long to make this page for you</h2>
 <h3>try again and hopefully we will be fast enough this time.

--- a/503.html
+++ b/503.html
@@ -6,6 +6,6 @@ body{text-align:center;position:absolute;top:50%;margin:0;margin-top:-275px;widt
 h2,h3{color:#555;font:bold 200%/100px sans-serif;margin:0}
 h3{color:#777;font:normal 150% sans-serif}
 </style>
-<img src=//www.redditstatic.com/heavy-load.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/heavy-load.png alt="">
 <h2>we took too long to make this page for you</h2>
 <h3>try again and hopefully we will be fast enough this time.

--- a/504.ad.html
+++ b/504.ad.html
@@ -3,4 +3,4 @@
 <style>
 *{margin:0;padding:0}
 </style>
-<img src=//www.redditstatic.com/ads/nBLi0LMkQY0.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/ads/nBLi0LMkQY0.png alt="">

--- a/504.down.html
+++ b/504.down.html
@@ -6,6 +6,6 @@ body{text-align:center;position:absolute;top:50%;margin:0;margin-top:-275px;widt
 h2,h3{color:#555;font:bold 200%/100px sans-serif;margin:0}
 h3{color:#777;font:normal 150% sans-serif}
 </style>
-<img src=//www.redditstatic.com/heavy-load.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/heavy-load.png alt="">
 <h2>we took too long to make this page for you</h2>
 <h3>try again and hopefully we will be fast enough this time.

--- a/504.html
+++ b/504.html
@@ -6,6 +6,6 @@ body{text-align:center;position:absolute;top:50%;margin:0;margin-top:-275px;widt
 h2,h3{color:#555;font:bold 200%/100px sans-serif;margin:0}
 h3{color:#777;font:normal 150% sans-serif}
 </style>
-<img src=//www.redditstatic.com/heavy-load.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/heavy-load.png alt="">
 <h2>we took too long to make this page for you</h2>
 <h3>try again and hopefully we will be fast enough this time.

--- a/504.pay.reddit.com.html
+++ b/504.pay.reddit.com.html
@@ -6,7 +6,7 @@ body{text-align:center;position:absolute;top:50%;margin:0;margin-top:-335px;widt
 h2,h3{color:#222;font:bold 200%/100px sans-serif;margin:0}
 h3{color:#777;font:normal 150% sans-serif}
 </style>
-<img src=//www.redditstatic.com/reddit404a.png alt="">
+<img src=//s3.amazonaws.com/redditstatic/reddit404a.png alt="">
 <h2>Full site SSL is not yet supported!</h2>
 <h3>You're getting this because you're accessing pay.reddit.com while not
   using a secure connection. You were probably redirected here from another


### PR DESCRIPTION
Since we don't currently have valid SSL certs on Akamai, we need to rely
on S3's certs for its own hostnames.

Fixes #6.
