### PR TITLE
Fix the broken redditstatus link.

### DIFF
--- a/504.reallydown.html
+++ b/504.reallydown.html
@@ -155,7 +155,7 @@ messages = [
 	'time actually is going slower right now',
 	'did you see today\'s <a href="//xkcd.com">xkcd</a>?',
 	'go ahead, click refresh again.',
-	'there may be more information in <a href="https://twitter.com/#!/redditstatus">@redditstatus</a>',
+	'there may be more information in <a href="https://twitter.com/redditstatus">@redditstatus</a>',
 	'did you know we\'re open source? <a href="https://github.com/reddit/">see if you can find the bug</a>.',
 	'i wonder if you\'ll have a <img src="//www.redditstatic.com/mail.png" alt="orangered"> when reddit\'s back?',
 	'in the meantime, go check out what\'s new at <a href="http://redditgifts.com">redditgifts</a>!',


### PR DESCRIPTION
The [old link](https://twitter.com/#!/redditstatus) takes me to twitter's main page; I've replaced it with [this one](https://twitter.com/redditstatus) which takes me properly to the @redditstatus page.

This fixes the issue described in [this /r/bugs post](http://www.reddit.com/r/bugs/comments/35rgxl/the_reddit_is_down_pages_link_to_redditstatus/).