### PR TITLE
Move charset to be in head

### DIFF
--- a/504.reallydown.html
+++ b/504.reallydown.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<meta charset="utf-8">
 <head>
 <title>reddit is down</title>
+<meta charset="utf-8">
 <style>
 @font-face {
 	font-family: 'SilkscreenNormal';


### PR DESCRIPTION
<meta charset=""> should be in the head of a page. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta, if it is not it shows as an error in Firefox view source page, but otherwise no harm is done.
I think it should be fixed though.